### PR TITLE
normalize volume paths on creation so that there is no difference bet…

### DIFF
--- a/src/main/java/am/filesystem/FileSystemHelper.java
+++ b/src/main/java/am/filesystem/FileSystemHelper.java
@@ -29,6 +29,11 @@ import java.util.Set;
  */
 public final class FileSystemHelper
 {
+  /**
+   * Directory separator to be used internally.
+   */
+  public static final String DIRECTORY_SEPARATOR = "/";
+
   private FileSystemHelper()
   {
     // prevent instantiation
@@ -113,6 +118,18 @@ public final class FileSystemHelper
       catch (final IOException e)
       {
       }
+    }
+  }
+
+  public static String normalizePath(final String path)
+  {
+    if (File.separator.equals(FileSystemHelper.DIRECTORY_SEPARATOR))
+    {
+      return path;
+    }
+    else
+    {
+      return path.replace(File.separator, FileSystemHelper.DIRECTORY_SEPARATOR);
     }
   }
 }

--- a/src/main/java/am/filesystem/VolumeScanner.java
+++ b/src/main/java/am/filesystem/VolumeScanner.java
@@ -15,7 +15,6 @@
  */
 package am.filesystem;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,10 +29,6 @@ import am.filesystem.model.Volume;
  */
 public class VolumeScanner
 {
-  /**
-   * Directory separator to be used internally.
-   */
-  public static final String DIRECTORY_SEPARATOR = "/";
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(VolumeScanner.class);
   private final Volume volume;
   private final AppConfig config;
@@ -42,7 +37,6 @@ public class VolumeScanner
   {
     this.volume = v;
     this.config = config;
-
   }
 
   public void scan()
@@ -73,18 +67,6 @@ public class VolumeScanner
   public void setRootDirectory(Directory dir, Path path)
   {
     volume.setRoot(dir);
-    volume.setPath(normalizePath(path.toString()));
-  }
-
-  public String normalizePath(final String path)
-  {
-    if (File.separator.equals(DIRECTORY_SEPARATOR))
-    {
-      return path;
-    }
-    else
-    {
-      return path.replace(File.separator, DIRECTORY_SEPARATOR);
-    }
+    volume.setPath(FileSystemHelper.normalizePath(path.toString()));
   }
 }

--- a/src/main/java/am/processor/VolumeProcessor.java
+++ b/src/main/java/am/processor/VolumeProcessor.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import am.app.AppConfig;
+import am.filesystem.FileSystemHelper;
 import am.filesystem.model.Directory;
 import am.filesystem.model.File;
 import am.filesystem.model.FileState;
@@ -142,7 +143,7 @@ public class VolumeProcessor
   public Volume mergeVolume(Volume scannedVolume, Volume loadedVolume)
   {
     final Volume result = new Volume();
-    result.setPath(scannedVolume.getPath());
+    result.setPath(FileSystemHelper.normalizePath(scannedVolume.getPath()));
     final Directory root = mergeDirectory(scannedVolume.getRoot(), loadedVolume.getRoot());
     result.setRoot(root);
     return result;

--- a/src/test/java/am/filesystem/FileSystemHelperTest.java
+++ b/src/test/java/am/filesystem/FileSystemHelperTest.java
@@ -97,4 +97,17 @@ public class FileSystemHelperTest
             fileSmall, fileLarge
         }));
   }
+
+  @Test
+  public void testNormalizeEmpty()
+  {
+    Assert.assertEquals("Empty path remains empty.", FileSystemHelper.normalizePath(""), "");
+  }
+
+  @Test
+  public void testNormalizeUnix()
+  {
+    final String path = "/home/bob/sub";
+    Assert.assertEquals("Unix path remains empty.", FileSystemHelper.normalizePath(path), path);
+  }
 }


### PR DESCRIPTION
…ween a scanned and a loaded Windows path